### PR TITLE
 fix: Set template fields for each operator 

### DIFF
--- a/airflow_dbt_python/operators/dbt.py
+++ b/airflow_dbt_python/operators/dbt.py
@@ -53,6 +53,7 @@ class DbtBaseOperator(BaseOperator):
         "profiles_dir",
         "profile",
         "target",
+        "state",
     ]
 
     @apply_defaults
@@ -315,7 +316,6 @@ class DbtRunOperator(DbtBaseOperator):
         "select",
         "models",
         "exclude",
-        "state",
     ]
 
     def __init__(
@@ -350,7 +350,6 @@ class DbtSeedOperator(DbtBaseOperator):
     template_fields = DbtBaseOperator.template_fields + [
         "select",
         "exclude",
-        "state",
     ]
 
     def __init__(
@@ -387,7 +386,6 @@ class DbtTestOperator(DbtBaseOperator):
         "select",
         "models",
         "exclude",
-        "state",
     ]
 
     def __init__(
@@ -425,7 +423,6 @@ class DbtCompileOperator(DbtBaseOperator):
         "select",
         "models",
         "exclude",
-        "state",
     ]
 
     def __init__(

--- a/airflow_dbt_python/operators/dbt.py
+++ b/airflow_dbt_python/operators/dbt.py
@@ -53,10 +53,6 @@ class DbtBaseOperator(BaseOperator):
         "profiles_dir",
         "profile",
         "target",
-        "select",
-        "models",
-        "exclude",
-        "state",
     ]
 
     @apply_defaults
@@ -315,6 +311,13 @@ class DbtRunOperator(DbtBaseOperator):
     https://docs.getdbt.com/reference/commands/run.
     """
 
+    template_fields = DbtBaseOperator.template_fields + [
+        "select",
+        "models",
+        "exclude",
+        "state",
+    ]
+
     def __init__(
         self,
         full_refresh: Optional[bool] = None,
@@ -343,6 +346,12 @@ class DbtSeedOperator(DbtBaseOperator):
     documentation for the dbt command can be found here:
     https://docs.getdbt.com/reference/commands/seed.
     """
+
+    template_fields = DbtBaseOperator.template_fields + [
+        "select",
+        "exclude",
+        "state",
+    ]
 
     def __init__(
         self,
@@ -374,6 +383,13 @@ class DbtTestOperator(DbtBaseOperator):
     https://docs.getdbt.com/reference/commands/test.
     """
 
+    template_fields = DbtBaseOperator.template_fields + [
+        "select",
+        "models",
+        "exclude",
+        "state",
+    ]
+
     def __init__(
         self,
         data: Optional[bool] = None,
@@ -404,6 +420,13 @@ class DbtCompileOperator(DbtBaseOperator):
     documentation for the dbt command can be found here:
     https://docs.getdbt.com/reference/commands/compile.
     """
+
+    template_fields = DbtBaseOperator.template_fields + [
+        "select",
+        "models",
+        "exclude",
+        "state",
+    ]
 
     def __init__(
         self,
@@ -490,6 +513,11 @@ class DbtSnapshotOperator(DbtBaseOperator):
     https://docs.getdbt.com/reference/commands/snapshot.
     """
 
+    template_fields = DbtBaseOperator.template_fields + [
+        "select",
+        "exclude",
+    ]
+
     def __init__(
         self,
         select: Optional[list[str]] = None,
@@ -514,6 +542,12 @@ class DbtLsOperator(DbtBaseOperator):
     The documentation for the dbt command can be found here:
     https://docs.getdbt.com/reference/commands/list.
     """
+
+    template_fields = DbtBaseOperator.template_fields + [
+        "select",
+        "exclude",
+        "resource_types",
+    ]
 
     def __init__(
         self,
@@ -557,6 +591,11 @@ class DbtRunOperationOperator(DbtBaseOperator):
     The documentation for the dbt command can be found here:
     https://docs.getdbt.com/reference/commands/run-operation.
     """
+
+    template_fields = DbtBaseOperator.template_fields + [
+        "macro",
+        "args",
+    ]
 
     def __init__(
         self,
@@ -627,6 +666,12 @@ class DbtBuildOperator(DbtBaseOperator):
     full Documentation for the dbt build command can be found here:
     https://docs.getdbt.com/reference/commands/build.
     """
+
+    template_fields = DbtBaseOperator.template_fields + [
+        "select",
+        "exclude",
+        "models",
+    ]
 
     def __init__(
         self,

--- a/airflow_dbt_python/operators/dbt.py
+++ b/airflow_dbt_python/operators/dbt.py
@@ -667,7 +667,6 @@ class DbtBuildOperator(DbtBaseOperator):
     template_fields = DbtBaseOperator.template_fields + [
         "select",
         "exclude",
-        "models",
     ]
 
     def __init__(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "airflow-dbt-python"
-version = "0.9.1"
+version = "0.9.2"
 description = "A dbt operator for Airflow that uses the dbt Python package"
 authors = ["Tomás Farías Santana <tomas@tomasfarias.dev>"]
 license = "MIT"


### PR DESCRIPTION
Small bug is causing DAGs to fail rendering since template fields are missing. So we set them for each class to ensure they exist.