### PR TITLE
fix: Override BaseHook init to support Airflow v1

### DIFF
--- a/airflow_dbt_python/hooks/dbt.py
+++ b/airflow_dbt_python/hooks/dbt.py
@@ -384,6 +384,9 @@ class DbtHook(BaseHook):
     Allows for running dbt tasks and provides required configurations for each task.
     """
 
+    def __init__(self):
+        pass
+
     def get_config_factory(self, command: str) -> ConfigFactory:
         """Get a ConfigFactory given a dbt command string."""
         return ConfigFactory.from_str(command)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "airflow-dbt-python"
-version = "0.9.2"
+version = "0.9.3"
 description = "A dbt operator for Airflow that uses the dbt Python package"
 authors = ["Tomás Farías Santana <tomas@tomasfarias.dev>"]
 license = "MIT"


### PR DESCRIPTION
Aiflow v1's `BaseHook` has the following `__init__` signature:

```python
def __init__(self, source):
```

This `source` argument is not used by us (or anywhere else in `BaseHook`), so we override it to not require it.