### PR TITLE
feat(operator): Add new operator for dbt docs generate

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Currently, the following `dbt` commands are supported:
 * `compile`
 * `debug`
 * `deps`
+* `docs generate`
 * `ls`
 * `parse`
 * `run`

--- a/airflow_dbt_python/__version__.py
+++ b/airflow_dbt_python/__version__.py
@@ -2,4 +2,4 @@
 __author__ = "Tomás Farías Santana"
 __copyright__ = "Copyright 2021 Tomás Farías Santana"
 __title__ = "airflow-dbt-python"
-__version__ = "0.10.2"
+__version__ = "0.11.0"

--- a/airflow_dbt_python/hooks/dbt.py
+++ b/airflow_dbt_python/hooks/dbt.py
@@ -25,6 +25,7 @@ from dbt.task.compile import CompileTask
 from dbt.task.debug import DebugTask
 from dbt.task.deps import DepsTask
 from dbt.task.freshness import FreshnessTask
+from dbt.task.generate import GenerateTask
 from dbt.task.list import ListTask
 from dbt.task.parse import ParseTask
 from dbt.task.run import RunTask
@@ -322,6 +323,15 @@ class DepsTaskConfig(BaseConfig):
 
 
 @dataclass
+class GenerateTaskConfig(SelectionConfig):
+    """Generate task arguments."""
+
+    cls: BaseTask = dataclasses.field(default=GenerateTask, init=False)
+    compile: bool = True
+    which: str = dataclasses.field(default="generate", init=False)
+
+
+@dataclass
 class ListTaskConfig(SelectionConfig):
     """Dbt list task arguments."""
 
@@ -428,6 +438,7 @@ class ConfigFactory(FromStrMixin, Enum):
     CLEAN = CleanTaskConfig
     DEBUG = DebugTaskConfig
     DEPS = DepsTaskConfig
+    GENERATE = GenerateTaskConfig
     LIST = ListTaskConfig
     PARSE = ParseTaskConfig
     RUN = RunTaskConfig

--- a/examples/dbt_project_in_s3_dag.py
+++ b/examples/dbt_project_in_s3_dag.py
@@ -3,7 +3,7 @@ import datetime as dt
 
 from airflow import DAG
 from airflow.utils.dates import days_ago
-from airflow_dbt_python.dbt.operators import DbtRunOperator
+from airflow_dbt_python.dbt.operators import DbtDocsGenerateOperator, DbtRunOperator
 
 with DAG(
     dag_id="example_basic_dbt_run_with_s3",
@@ -12,6 +12,7 @@ with DAG(
     catchup=False,
     dagrun_timeout=dt.timedelta(minutes=60),
 ) as dag:
+    # Project files will be pulled from "s3://my-bucket/dbt/profiles/key/prefix/"
     dbt_run = DbtRunOperator(
         task_id="dbt_run_hourly",
         project_dir="s3://my-bucket/dbt/project/key/prefix/",
@@ -22,3 +23,13 @@ with DAG(
         profile="my-project",
         full_refresh=False,
     )
+
+    # Documentation files (target/manifest.json, target/index.html, and
+    # target/catalog.json) will be pushed back to S3 after compilation is done.
+    dbt_docs = DbtDocsGenerateOperator(
+        task_id="dbt_run_hourly",
+        project_dir="s3://my-bucket/dbt/project/key/prefix/",
+        profiles_dir="s3://my-bucket/dbt/profiles/key/prefix/",
+    )
+
+    dbt_run >> dbt_docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "airflow-dbt-python"
-version = "0.10.2"
+version = "0.11.0"
 description = "A dbt operator and hook for Airflow"
 authors = ["Tomás Farías Santana <tomas@tomasfarias.dev>"]
 license = "MIT"

--- a/tests/hooks/dbt/test_dbt_generate.py
+++ b/tests/hooks/dbt/test_dbt_generate.py
@@ -1,0 +1,64 @@
+"""Unit test module for running dbt docs generate with the DbtHook."""
+
+
+def test_dbt_docs_generate_task(hook, profiles_file, dbt_project_file, model_files):
+    """Test a dbt docs generate task."""
+    import shutil
+
+    target_dir = dbt_project_file.parent / "target"
+    if target_dir.exists() is True:
+        shutil.rmtree(target_dir)
+    assert target_dir.exists() is False
+
+    factory = hook.get_config_factory("generate")
+    config = factory.create_config(
+        project_dir=dbt_project_file.parent,
+        profiles_dir=profiles_file.parent,
+    )
+    success, results = hook.run_dbt_task(config)
+
+    assert success is True
+    assert results is not None
+    assert target_dir.exists() is True
+
+    index = target_dir / "index.html"
+    assert index.exists() is True
+
+    manifest = target_dir / "manifest.json"
+    assert manifest.exists() is True
+
+    catalog = target_dir / "catalog.json"
+    assert catalog.exists() is True
+
+
+def test_dbt_docs_generate_task_no_compile(
+    hook, profiles_file, dbt_project_file, model_files
+):
+    """Test a dbt docs generate task without compiling."""
+    import shutil
+
+    target_dir = dbt_project_file.parent / "target"
+    if target_dir.exists() is True:
+        shutil.rmtree(target_dir)
+    assert target_dir.exists() is False
+
+    factory = hook.get_config_factory("generate")
+    config = factory.create_config(
+        project_dir=dbt_project_file.parent,
+        profiles_dir=profiles_file.parent,
+        compile=False,
+    )
+    success, results = hook.run_dbt_task(config)
+
+    assert success is True
+    assert results is not None
+    assert target_dir.exists() is True
+
+    index = target_dir / "index.html"
+    assert index.exists() is True
+
+    manifest = target_dir / "manifest.json"
+    assert manifest.exists() is False
+
+    catalog = target_dir / "catalog.json"
+    assert catalog.exists() is True

--- a/tests/operators/test_dbt_deps.py
+++ b/tests/operators/test_dbt_deps.py
@@ -6,6 +6,15 @@ import pytest
 from airflow_dbt_python.hooks.dbt import DepsTaskConfig
 from airflow_dbt_python.operators.dbt import DbtDepsOperator
 
+condition = False
+try:
+    from airflow_dbt_python.hooks.s3 import DbtS3Hook
+except ImportError:
+    condition = True
+no_s3_hook = pytest.mark.skipif(
+    condition, reason="S3Hook not available, consider installing amazon extras"
+)
+
 
 def test_dbt_deps_mocked_all_args():
     """Test mocked dbt deps call with all arguments."""
@@ -54,3 +63,61 @@ def test_dbt_deps_downloads_dbt_utils(
 
     modules = dbt_packages_dir.glob("dbt_utils")
     assert len([m for m in modules]) == 1
+
+
+@no_s3_hook
+def test_dbt_deps_push_to_s3(
+    s3_bucket,
+    profiles_file,
+    dbt_project_file,
+    packages_file,
+):
+    """Test execution of DbtDepsOperator with a push to S3 at the end."""
+    hook = DbtS3Hook()
+    bucket = hook.get_bucket(s3_bucket)
+
+    with open(dbt_project_file) as pf:
+        project_content = pf.read()
+    bucket.put_object(Key="project/dbt_project.yml", Body=project_content.encode())
+
+    with open(profiles_file) as pf:
+        profiles_content = pf.read()
+    bucket.put_object(Key="project/profiles.yml", Body=profiles_content.encode())
+
+    with open(packages_file) as pf:
+        packages_content = pf.read()
+    bucket.put_object(Key="project/packages.yml", Body=packages_content.encode())
+
+    # Ensure we are working with an empty dbt_packages dir in S3.
+    keys = hook.list_keys(
+        s3_bucket,
+        f"s3://{s3_bucket}/project/dbt_packages/",
+    )
+    if keys is not None and len(keys) > 0:
+        hook.delete_objects(
+            s3_bucket,
+            keys,
+        )
+        keys = hook.list_keys(
+            s3_bucket,
+            f"s3://{s3_bucket}/project/dbt_packages/",
+        )
+    assert keys is None or len(keys) == 0
+
+    op = DbtDepsOperator(
+        task_id="dbt_task",
+        project_dir=f"s3://{s3_bucket}/project/",
+        profiles_dir=f"s3://{s3_bucket}/project/",
+        push_dbt_project=True,
+    )
+    results = op.execute({})
+    assert results is None
+
+    keys = hook.list_keys(
+        s3_bucket,
+        f"s3://{s3_bucket}/project/dbt_packages/",
+    )
+    assert len(keys) >= 0
+    # dbt_utils files may be anything, let's just check that at least
+    # "dbt_utils" exists as part of the key.
+    assert len([k for k in keys if "dbt_utils" in k]) >= 0

--- a/tests/operators/test_dbt_docs_generate.py
+++ b/tests/operators/test_dbt_docs_generate.py
@@ -1,0 +1,127 @@
+"""Unit test module for DbtDocsGenerateOperator."""
+from unittest.mock import patch
+
+import pytest
+
+from airflow_dbt_python.hooks.dbt import GenerateTaskConfig
+from airflow_dbt_python.operators.dbt import DbtDocsGenerateOperator
+
+condition = False
+try:
+    from airflow_dbt_python.hooks.s3 import DbtS3Hook
+except ImportError:
+    condition = True
+no_s3_hook = pytest.mark.skipif(
+    condition, reason="S3Hook not available, consider installing amazon extras"
+)
+
+
+def test_dbt_docs_generate_config_all_args():
+    """Test mocked dbt docs generate call with all arguments."""
+    op = DbtDocsGenerateOperator(
+        task_id="dbt_task",
+        project_dir="/path/to/project/",
+        profiles_dir="/path/to/profiles/",
+        profile="dbt-profile",
+        target="dbt-target",
+        compile=False,
+        push_dbt_project=False,
+    )
+    assert op.command == "generate"
+
+    config = op.get_dbt_config()
+    assert isinstance(config, GenerateTaskConfig) is True
+    assert config.project_dir == "/path/to/project/"
+    assert config.profiles_dir == "/path/to/profiles/"
+    assert config.profile == "dbt-profile"
+    assert config.target == "dbt-target"
+    assert config.compile is False
+    assert op.push_dbt_project is False
+
+
+def test_dbt_docs_generate_produces_documentation_files(
+    profiles_file,
+    dbt_project_file,
+    model_files,
+    seed_files,
+):
+    """Test that a DbtDocsGenerateOperator generates documentation files."""
+    import shutil
+
+    # Ensure target directory is empty before starting
+    target_dir = dbt_project_file.parent / "target"
+    shutil.rmtree(target_dir, ignore_errors=True)
+
+    assert target_dir.exists() is False
+
+    op = DbtDocsGenerateOperator(
+        task_id="dbt_task",
+        project_dir=dbt_project_file.parent,
+        profiles_dir=profiles_file.parent,
+    )
+
+    op.execute({})
+
+    assert target_dir.exists() is True
+
+    files = [f.name for f in target_dir.glob("*")]
+    assert "manifest.json" in files
+    assert "catalog.json" in files
+    assert "index.html" in files
+
+
+@no_s3_hook
+def test_dbt_docs_generate_push_to_s3(
+    s3_bucket, profiles_file, dbt_project_file, model_files
+):
+    """Test execution of DbtDocsGenerateOperator with a push to S3 at the end."""
+    hook = DbtS3Hook()
+    bucket = hook.get_bucket(s3_bucket)
+
+    with open(dbt_project_file) as pf:
+        project_content = pf.read()
+    bucket.put_object(Key="project/dbt_project.yml", Body=project_content.encode())
+
+    with open(profiles_file) as pf:
+        profiles_content = pf.read()
+    bucket.put_object(Key="project/profiles.yml", Body=profiles_content.encode())
+
+    for model_file in model_files:
+        with open(model_file) as mf:
+            model_content = mf.read()
+            bucket.put_object(
+                Key=f"project/models/{model_file.name}", Body=model_content.encode()
+            )
+
+    # Ensure we are working with an empty target in S3.
+    keys = hook.list_keys(
+        s3_bucket,
+        f"s3://{s3_bucket}/project/target/",
+    )
+    if keys is not None and len(keys) > 0:
+        hook.delete_objects(
+            s3_bucket,
+            keys,
+        )
+        keys = hook.list_keys(
+            s3_bucket,
+            f"s3://{s3_bucket}/project/target/",
+        )
+    assert keys is None or len(keys) == 0
+
+    op = DbtDocsGenerateOperator(
+        task_id="dbt_task",
+        project_dir=f"s3://{s3_bucket}/project/",
+        profiles_dir=f"s3://{s3_bucket}/project/",
+        push_dbt_project=True,
+    )
+    results = op.execute({})
+    assert results is not None
+
+    keys = hook.list_keys(
+        s3_bucket,
+        f"s3://{s3_bucket}/project/target/",
+    )
+    assert f"s3://{s3_bucket}/project/target/manifest.json" in keys
+    assert f"s3://{s3_bucket}/project/target/catalog.json" in keys
+    assert f"s3://{s3_bucket}/project/target/index.html" in keys


### PR DESCRIPTION
Support for dbt docs generate itself is pretty trivial as we only needed a
new configuration and dbt docs generate does not take many
configuration arguments. The biggest challenge of supporting dbt docs generate
is solving the issue of running dbt docs generate in a temporary
directory: there isn't much sense in executing dbt docs generate if we
cannot use the results of the execution. The alternative of pushing
the dbt artifacts to XCom is, of course, still available, but I wanted
to use this an excuse to develop something else.

So, we also added a push_dbt_project method to our S3
hook. This method is called right before exiting the temporary
directory, and can be controlled with a push_dbt_project argument to
the operator. The argument is by default True for the new
DbtDocsGenerateOperator so that we can push the documentation files to
S3. It is also True by default when running DbtDepsOperator since
there was no way for us install dependencies.

In the future, I'd like us to support more "dbt backends" besides S3:
maybe support for pulling projects from Github? SSH and SFTP
connections? Lots of possibilities!

Closes #26 