### PR TITLE
chore: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,15 @@
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+
   - repo: https://github.com/psf/black
-    rev: 21.5b1
+    rev: 22.1.0
     hooks:
     - id: black
+      name: Python code formatting
       types_or: [python, pyi]
 
   - repo: https://gitlab.com/pycqa/flake8
@@ -11,12 +18,14 @@ repos:
       - id: flake8
         additional_dependencies: [flake8-docstrings]
         args: ["--config", ".flake8"]
+        name: PEP8 enforcement
         exclude: tests/
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.902
     hooks:
       - id: mypy
+        name: Static type checking
         additional_dependencies: ["types-freezegun==1.1.6"]
 
   - repo: https://github.com/pycqa/isort
@@ -24,4 +33,10 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
+        name: Sort import statements
         args: ["--profile", "black", "--filter-files"]
+
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.1.0
+    hooks:
+      - id: detect-secrets


### PR DESCRIPTION
Minor updates to pre-commit hooks, including the latest black release as in #33 