### PR TITLE
Closes #10 Adding vars as a template_field to DbtBaseOperator

### DIFF
--- a/airflow_dbt_python/operators/dbt.py
+++ b/airflow_dbt_python/operators/dbt.py
@@ -48,6 +48,7 @@ class DbtBaseOperator(BaseOperator):
         "profile",
         "target",
         "state",
+        "vars",
     ]
 
     @apply_defaults


### PR DESCRIPTION
Adding vars to the list of template_fields on the DbtBaseOperator.

This will allow passing variables to the operator from the dag_run.conf