### PR TITLE
chore: Bump minor version

### DIFF
--- a/airflow_dbt_python/__version__.py
+++ b/airflow_dbt_python/__version__.py
@@ -2,4 +2,4 @@
 __author__ = "Tomás Farías Santana"
 __copyright__ = "Copyright 2021 Tomás Farías Santana"
 __title__ = "airflow-dbt-python"
-__version__ = "0.12.0"
+__version__ = "0.13.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "airflow-dbt-python"
-version = "0.13.0-alpha.2"
+version = "0.13.0"
 description = "A dbt operator and hook for Airflow"
 authors = ["Tomás Farías Santana <tomas@tomasfarias.dev>"]
 license = "MIT"


### PR DESCRIPTION
I was hesitant to release v0.13.0 due to how much code we refactored. But I've changed my mind: pre-release has been out for a week, and it has started to block other issues.