### PR TITLE
fix(s3): Split bucket name and key before uploading

### DIFF
--- a/airflow_dbt_python/__version__.py
+++ b/airflow_dbt_python/__version__.py
@@ -2,4 +2,4 @@
 __author__ = "Tomás Farías Santana"
 __copyright__ = "Copyright 2021 Tomás Farías Santana"
 __title__ = "airflow-dbt-python"
-__version__ = "0.13.0"
+__version__ = "0.13.1"

--- a/airflow_dbt_python/hooks/backends/s3.py
+++ b/airflow_dbt_python/hooks/backends/s3.py
@@ -121,7 +121,7 @@ class DbtS3Backend(DbtBackend):
         all_files = Path(source).glob("**/*")
 
         if delete_before:
-            keys = self.hook.list_keys(bucket_name, destination)
+            keys = self.hook.list_keys(bucket_name)
             self.hook.delete_objects(bucket_name, keys)
 
         if key.endswith(".zip"):

--- a/airflow_dbt_python/hooks/backends/s3.py
+++ b/airflow_dbt_python/hooks/backends/s3.py
@@ -121,7 +121,7 @@ class DbtS3Backend(DbtBackend):
         all_files = Path(source).glob("**/*")
 
         if delete_before:
-            keys = self.hook.list_keys(bucket_name)
+            keys = self.hook.list_keys(bucket_name, prefix=key)
             self.hook.delete_objects(bucket_name, keys)
 
         if key.endswith(".zip"):
@@ -230,6 +230,10 @@ class DbtS3Backend(DbtBackend):
         success = True
 
         if bucket_name is None:
+            # We can't call S3Hook.load_file with bucket_name=None as it checks for the
+            # presence of the parameter to decide whether setting a bucket_name is
+            # required. By passing bucket_name=None, the parameter is set, and
+            # 'None' will be used as the bucket name.
             bucket_name, key = self.hook.parse_s3_url(key)
 
         self.log.info("Loading file %s to S3: %s", file_path, key)

--- a/airflow_dbt_python/hooks/backends/s3.py
+++ b/airflow_dbt_python/hooks/backends/s3.py
@@ -92,12 +92,9 @@ class DbtS3Backend(DbtBackend):
                 name and key prefix will be extracted by calling S3Hook.parse_s3_url.
             replace (bool): Whether to replace existing files or not.
         """
-        bucket_name, key = self.hook.parse_s3_url(str(destination))
-
         self.load_file_handle_replace_error(
             Path(source),
-            key=key,
-            bucket_name=bucket_name,
+            key=str(destination),
             replace=replace,
         )
 
@@ -134,7 +131,6 @@ class DbtS3Backend(DbtBackend):
             self.load_file_handle_replace_error(
                 Path(zip_path),
                 key=str(destination),
-                bucket_name=bucket_name,
                 replace=replace,
             )
 
@@ -148,7 +144,6 @@ class DbtS3Backend(DbtBackend):
                 self.load_file_handle_replace_error(
                     _file,
                     key=s3_key,
-                    bucket_name=bucket_name,
                     replace=replace,
                 )
 
@@ -233,6 +228,9 @@ class DbtS3Backend(DbtBackend):
             True if no ValueError was raised, False otherwise.
         """
         success = True
+
+        if bucket_name is None:
+            bucket_name, key = self.hook.parse_s3_url(key)
 
         self.log.info("Loading file %s to S3: %s", file_path, key)
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "airflow-dbt-python"
-version = "0.13.0"
+version = "0.13.1"
 description = "A dbt operator and hook for Airflow"
 authors = ["Tomás Farías Santana <tomas@tomasfarias.dev>"]
 license = "MIT"

--- a/tests/hooks/dbt/backends/test_dbt_s3_backend.py
+++ b/tests/hooks/dbt/backends/test_dbt_s3_backend.py
@@ -277,8 +277,6 @@ def test_push_dbt_project_to_zip_file(s3_bucket, s3_hook, tmpdir, test_files):
     backend = DbtS3Backend()
     backend.push_dbt_project(test_files[0].parent.parent, zip_s3_key)
 
-    keys = s3_hook.list_keys(s3_bucket, f"s3://{s3_bucket}/project/")
-
     key = s3_hook.check_for_key(
         "project/project.zip",
         s3_bucket,

--- a/tests/hooks/dbt/backends/test_dbt_s3_backend.py
+++ b/tests/hooks/dbt/backends/test_dbt_s3_backend.py
@@ -280,10 +280,13 @@ def test_push_dbt_project_to_zip_file(s3_bucket, s3_hook, tmpdir, test_files):
     keys = s3_hook.list_keys(s3_bucket, f"s3://{s3_bucket}/project/")
 
     key = s3_hook.check_for_key(
-        zip_s3_key,
+        "project/project.zip",
         s3_bucket,
     )
+    keys = s3_hook.list_keys(bucket_name=s3_bucket)
+
     assert key is True
+    assert "project/project.zip" in keys
 
 
 def test_push_dbt_project_to_files(s3_bucket, s3_hook, tmpdir, test_files):

--- a/tests/operators/test_dbt_clean.py
+++ b/tests/operators/test_dbt_clean.py
@@ -100,12 +100,12 @@ def test_dbt_clean_after_compile_in_s3(
     # Run compile first to ensure a target/ directory exists to be cleaned
     comp.execute({})
 
-    keys = s3_hook.list_keys(s3_bucket, f"s3://{s3_bucket}/project/target")
+    keys = s3_hook.list_keys(s3_bucket, prefix="project/target")
     assert len(keys) > 0
 
     clean_result = op.execute({})
 
     assert clean_result is None
 
-    keys = s3_hook.list_keys(s3_bucket, f"s3://{s3_bucket}/project/target")
+    keys = s3_hook.list_keys(s3_bucket, prefix="project/target")
     assert len(keys) == 0

--- a/tests/operators/test_dbt_docs_generate.py
+++ b/tests/operators/test_dbt_docs_generate.py
@@ -93,19 +93,13 @@ def test_dbt_docs_generate_push_to_s3(
             )
 
     # Ensure we are working with an empty target in S3.
-    keys = s3_hook.list_keys(
-        s3_bucket,
-        f"s3://{s3_bucket}/project/target/",
-    )
+    keys = s3_hook.list_keys(s3_bucket, "project/target")
     if keys is not None and len(keys) > 0:
         s3_hook.delete_objects(
             s3_bucket,
             keys,
         )
-        keys = s3_hook.list_keys(
-            s3_bucket,
-            f"s3://{s3_bucket}/project/target/",
-        )
+        keys = s3_hook.list_keys(s3_bucket, "project/target")
     assert keys is None or len(keys) == 0
 
     op = DbtDocsGenerateOperator(
@@ -117,10 +111,7 @@ def test_dbt_docs_generate_push_to_s3(
     results = op.execute({})
     assert results is not None
 
-    keys = s3_hook.list_keys(
-        s3_bucket,
-        f"s3://{s3_bucket}/project/target/",
-    )
-    assert f"s3://{s3_bucket}/project/target/manifest.json" in keys
-    assert f"s3://{s3_bucket}/project/target/catalog.json" in keys
-    assert f"s3://{s3_bucket}/project/target/index.html" in keys
+    keys = s3_hook.list_keys(s3_bucket)
+    assert f"project/target/manifest.json" in keys
+    assert f"project/target/catalog.json" in keys
+    assert f"project/target/index.html" in keys


### PR DESCRIPTION
S3 files were uploaded to incorrect keys when running Airflow 2. This
was caused by differences between Airflow 1.10 and Airflow 2: the
latter assumes that when passing both bucket_name and key that the key
is to be taken as it is, where as the former seemed to work even when
the key contained the full url.

Now, we do the parsing and splitting ourselves. We would just set
bucket_name to None, however with Airflow 2.0 the upload function
checks for the presence of the bucket_name argument, to decide whether
to parse the url, not if it's set to None (I think this may be a bug).