### PR TITLE
fix: Set results before running task to avoid UnboundLocalError

### DIFF
--- a/airflow_dbt_python/hooks/dbt.py
+++ b/airflow_dbt_python/hooks/dbt.py
@@ -572,6 +572,8 @@ class DbtHook(BaseHook):
             # before deps runs and the following would raise a CompilationError.
             runtime_config.load_dependencies()
 
+        results = None
+
         with adapter_management():
             register_adapter(runtime_config)
 


### PR DESCRIPTION
dbt handles exceptions raised by task.run() with the track_run context
manager. We are also doing the same thing. The problem is that some
exceptions, like FailedToConnectException, are failing silently (at
least for us, CLI users do see a log) and are not re-raised by
dbt.

Continuing with execution would lead to an UnboundLocalError as
we don't account for results never being set. To address this we
preemptively set results to None before running a task.

Closes #49 