### PR TITLE
feat: Support Python 3.10

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,8 +13,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, '3.10']
         airflow-version: ['1.10.15', '2.0.2', '2.2.5']
+        exclude:
+          - python-version: '3.10'
+            airflow-version: '2.0.2'
+          - python-version: '3.10'
+            airflow-version: '1.10.15'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -42,9 +47,16 @@ jobs:
         run: poetry run black --check .
 
       - name: Install Airflow > 2
-        if: matrix.airflow-version != '1.10.15'
+        if: matrix.airflow-version != '1.10.15' && matrix.python-version != '3.10'
         run: |
           wget https://raw.githubusercontent.com/apache/airflow/constraints-${{ matrix.airflow-version }}/constraints-${{ matrix.python-version }}.txt -O constraints.txt
+          poetry run pip install apache-airflow==${{ matrix.airflow-version }} apache-airflow-providers-amazon -c constraints.txt
+          poetry run airflow db init
+
+      - name: Install Airflow > 2
+        if: matrix.airflow-version != '1.10.15' && matrix.python-version == '3.10'
+        run: |
+          wget https://raw.githubusercontent.com/apache/airflow/constraints-${{ matrix.airflow-version }}/constraints-3.9.txt -O constraints.txt
           poetry run pip install apache-airflow==${{ matrix.airflow-version }} apache-airflow-providers-amazon -c constraints.txt
           poetry run airflow db init
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Read the [documentation](https://tomasfarias.github.io/airflow-dbt-python/) for 
 
 airflow-dbt-python requires the latest major version of [`dbt-core`](https://pypi.org/project/dbt-core/) which at the time of writing is version 1. Since `dbt-core` follows [semantic versioning](https://semver.org/), we do not impose any restrictions on the minor and patch versions, but do keep in mind that the latest `dbt-core` features incorporated as minor releases may not yet be supported.
 
-To line up with `dbt-core`, airflow-dbt-python supports Python 3.7, 3.8, and 3.9. We also include Python 3.10 in our testing pipeline, although as of the time of writing `dbt-core` does not yet support it.
+To line up with `dbt-core`, airflow-dbt-python supports Python 3.7, 3.8, 3.9, and 3.10. However, due to installation conflicts, we only test Python 3.10 with `apache-airflow>=2.2`.
 
 Due to the dependency conflict, airflow-dbt-python **does not include Airflow as a dependency**. We expect airflow-dbt-python to be installed into an environment with Airflow already in it. For more detailed instructions see the [docs](https://tomasfarias.github.io/airflow-dbt-python/getting_started.html).
 
@@ -32,6 +32,7 @@ pip install airflow-dby-python[snowflake,postgres]
 ```
 
 ## From this repo:
+
 
 Clone the repo:
 ``` shell

--- a/airflow_dbt_python/__version__.py
+++ b/airflow_dbt_python/__version__.py
@@ -2,4 +2,4 @@
 __author__ = "Tomás Farías Santana"
 __copyright__ = "Copyright 2021 Tomás Farías Santana"
 __title__ = "airflow-dbt-python"
-__version__ = "0.14.2"
+__version__ = "0.14.3"

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -10,7 +10,10 @@ Requirements
 
 airflow-dbt-python requires the latest major version of `dbt-core <https://pypi.org/project/dbt-core/>`_ which at the time of writing is version 1. Since ``dbt-core`` follows `semantic versioning <https://semver.org/>`_, we do not impose any restrictions on the minor and patch versions, but do keep in mind that the latest ``dbt-core`` features incorporated as minor releases may not yet be supported.
 
-To line up with ``dbt-core``, airflow-dbt-python supports Python 3.7, 3.8, and 3.9. We also include Python 3.10 in our testing pipeline, although as of the time of writing ``dbt-core`` does not yet support it.
+To line up with ``dbt-core``, airflow-dbt-python supports Python 3.7, 3.8, 3.9, and 3.10.
+
+.. note::
+   Due to installation conflicts, we only test Python 3.10 with `apache-airflow>=2.2`.
 
 On the Airflow side, we support the release version 1.10.12 and all Airflow major version 2 releases.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "airflow-dbt-python"
-version = "0.14.2"
+version = "0.14.3"
 description = "A dbt operator and hook for Airflow"
 authors = ["Tomás Farías Santana <tomas@tomasfarias.dev>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,11 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.7.2, <3.10.0"
+python = ">=3.7.2, <3.11.0"
 
 apache-airflow = { version = ">=2.2", optional = true }
 apache-airflow-providers-amazon = { version = ">=3.0.0", optional = true }


### PR DESCRIPTION
Closes #59

I'll consider Python 3.10 supported if we can get the testing pipeline to pass. That being said, I'm seeing issues with `apache-airflow==1.10.15` and `apache-airflow==2.0.2`, so I'll mention in the docs Python 3.10 is only tested in  `apache-airflow>=2.2`. Our dependencies already require `apache-airflow>=2.2`. 