### PR TITLE
feat(test): Add DAG that uses Airflow connection to tests

### DIFF
--- a/examples/use_dbt_artifacts_dag.py
+++ b/examples/use_dbt_artifacts_dag.py
@@ -2,7 +2,7 @@
 import datetime as dt
 
 from airflow import DAG
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python import PythonOperator
 from airflow.utils.dates import days_ago
 
 from airflow_dbt_python.operators.dbt import DbtRunOperator
@@ -71,6 +71,5 @@ with DAG(
     process_artifacts = PythonOperator(
         task_id="process_artifacts",
         python_callable=process_dbt_artifacts,
-        provide_context=True,
     )
     dbt_run >> process_artifacts

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,16 +3,15 @@
 Common fixtures include a connection to a postgres database, a set of sample model and
  seed files, dbt configuration files, and temporary directories for everything.
 """
-import os
 import shutil
 
 import boto3
 import pytest
+from airflow import settings
+from airflow.models.connection import Connection
 from moto import mock_s3
 from pytest_postgresql.janitor import DatabaseJanitor
 
-from airflow import settings
-from airflow.models.connection import Connection
 from airflow_dbt_python.hooks.dbt import DbtHook
 
 PROFILES = """

--- a/tests/dags/test_dbt_dags.py
+++ b/tests/dags/test_dbt_dags.py
@@ -274,8 +274,7 @@ def connection(database):
 
     yield conn_id
 
-    session.query(integration_test_conn).delete()
-    session.commit()
+    session.close()
 
 
 @pytest.fixture

--- a/tests/operators/test_dbt_test.py
+++ b/tests/operators/test_dbt_test.py
@@ -221,8 +221,8 @@ def test_dbt_test_with_project_from_s3(
         assert test_result["status"] == TestStatus.Pass
 
 
-def test_dbt_compile_uses_correct_argument_according_to_version():
-    """Test if dbt run operator sets the proper attribute based on dbt version."""
+def test_dbt_test_uses_correct_argument_according_to_version():
+    """Test if dbt test operator sets the proper attribute based on dbt version."""
     op = DbtTestOperator(
         task_id="dbt_task",
         project_dir="/path/to/project/",


### PR DESCRIPTION
In an effort to try and isolate the issue reported in #79, we add a new DAG to the integration tests that setups an Airflow connection in a similar fashion to the example DAG.

The test is passing, however once more details are provided, it may be extended to attempt to replicate the issue.