### PR TITLE
chore: Update flake8 pre-commit URL to point to GitHub repository

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,8 +12,8 @@ repos:
       name: Python code formatting
       types_or: [python, pyi]
 
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+  - repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
     hooks:
       - id: flake8
         additional_dependencies: [flake8-docstrings]


### PR DESCRIPTION
`flake8` has been [migrated to GitHub](https://twitter.com/codewithanthony/status/1378746934928699396), and the GitLab repository has been deleted.

For existing contributors, `pre-commit` still works because a virtualenv with the current configured `flake8` version is cached. However, cleaning up the cache and trying to run `pre-commit run` is enough to reproduce the issue.