### PR TITLE
fix: Avoid heavy imports in operator constructor

### DIFF
--- a/airflow_dbt_python/hooks/dbt.py
+++ b/airflow_dbt_python/hooks/dbt.py
@@ -6,7 +6,6 @@ import json
 import os
 import pickle
 from dataclasses import dataclass
-from enum import Enum
 from pathlib import Path
 from typing import Any, Optional, Type, Union
 from urllib.parse import urlparse
@@ -50,39 +49,9 @@ try:
 except ImportError:
     from airflow.hooks.base_hook import BaseHook  # type: ignore
 
+from airflow_dbt_python.utils.enums import FromStrEnum, LogFormat, Output
+
 from .backends import DbtBackend, StrPath, build_backend
-
-
-class FromStrEnum(Enum):
-    """Access enum variants with strings ensuring uppercase."""
-
-    @classmethod
-    def from_str(cls, s: str):
-        """Instantiate an Enum from a string."""
-        return cls[s.replace("-", "_").upper()]
-
-
-class LogFormat(FromStrEnum):
-    """Allowed dbt log formats."""
-
-    DEFAULT = "default"
-    JSON = "json"
-    TEXT = "text"
-
-
-class Output(FromStrEnum):
-    """Allowed output arguments."""
-
-    JSON = "json"
-    NAME = "name"
-    PATH = "path"
-    SELECTOR = "selector"
-
-    def __eq__(self, other):
-        """Override equality for string comparison."""
-        if isinstance(other, str):
-            return other.upper() == self.name
-        return Enum.__eq__(self, other)
 
 
 def parse_yaml_args(args: Optional[Union[str, dict[str, Any]]]) -> dict[str, Any]:

--- a/airflow_dbt_python/operators/dbt.py
+++ b/airflow_dbt_python/operators/dbt.py
@@ -15,6 +15,8 @@ from airflow.models.baseoperator import BaseOperator
 from airflow.models.xcom import XCOM_RETURN_KEY
 from airflow.version import version
 
+from airflow_dbt_python.utils.enums import LogFormat, Output
+
 # apply_defaults is deprecated in version 2 and beyond. This allows us to
 # support version 1 and deal with the deprecation warning.
 if int(version[0]) == 1:
@@ -110,8 +112,6 @@ class DbtBaseOperator(BaseOperator):
         replace_on_push: bool = False,
         **kwargs,
     ) -> None:
-        from airflow_dbt_python.hooks.dbt import LogFormat
-
         super().__init__(**kwargs)
         self.project_dir = project_dir
         self.profiles_dir = profiles_dir
@@ -618,8 +618,6 @@ class DbtLsOperator(DbtBaseOperator):
         indirect_selection: Optional[str] = None,
         **kwargs,
     ) -> None:
-        from airflow_dbt_python.hooks.dbt import Output
-
         super().__init__(**kwargs)
         self.resource_types = resource_types
         self.select = select

--- a/airflow_dbt_python/utils/__init__.py
+++ b/airflow_dbt_python/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utils for project operators and hooks."""

--- a/airflow_dbt_python/utils/enums.py
+++ b/airflow_dbt_python/utils/enums.py
@@ -1,0 +1,34 @@
+"""Enumerations with allowed set of values."""
+from enum import Enum
+
+
+class FromStrEnum(Enum):
+    """Access enum variants with strings ensuring uppercase."""
+
+    @classmethod
+    def from_str(cls, s: str):
+        """Instantiate an Enum from a string."""
+        return cls[s.replace("-", "_").upper()]
+
+
+class LogFormat(FromStrEnum):
+    """Allowed dbt log formats."""
+
+    DEFAULT = "default"
+    JSON = "json"
+    TEXT = "text"
+
+
+class Output(FromStrEnum):
+    """Allowed output arguments."""
+
+    JSON = "json"
+    NAME = "name"
+    PATH = "path"
+    SELECTOR = "selector"
+
+    def __eq__(self, other):
+        """Override equality for string comparison."""
+        if isinstance(other, str):
+            return other.upper() == self.name
+        return Enum.__eq__(self, other)


### PR DESCRIPTION
After a previous commit [1] improving import time on operator import, this commit fixes the import time issues when instantiating any of the dbt operators.

The main issue still present was the enum imports in the operator constructors, which make DAGs slow to import any time they instantiated one of them.

Profiling can be easily run locally, with the following command:
```shell
python -X importtime -c "from airflow_dbt_python.operators.dbt import DbtRunOperator; DbtRunOperator(task_id='test')" 2>import-times.log
```

[1] https://github.com/tomasfarias/airflow-dbt-python/commit/67c8d7866235e105675bd208659aac2ccc26070e