### PR TITLE
fix: Conditional import for different dbt exceptions

### DIFF
--- a/airflow_dbt_python/__version__.py
+++ b/airflow_dbt_python/__version__.py
@@ -2,4 +2,4 @@
 __author__ = "Tomás Farías Santana"
 __copyright__ = "Copyright 2021 Tomás Farías Santana"
 __title__ = "airflow-dbt-python"
-__version__ = "0.15.2"
+__version__ = "0.15.3"

--- a/airflow_dbt_python/hooks/dbt.py
+++ b/airflow_dbt_python/hooks/dbt.py
@@ -23,7 +23,6 @@ from dbt.config.runtime import RuntimeConfig, UnsetProfileConfig
 from dbt.contracts.graph.manifest import Manifest
 from dbt.contracts.results import RunResult
 from dbt.events.functions import setup_event_logger
-from dbt.exceptions import InternalException
 from dbt.graph import Graph
 from dbt.main import adapter_management, track_run
 from dbt.task.base import BaseTask, move_to_nearest_project_dir
@@ -186,6 +185,11 @@ class BaseConfig:
         Raises:
             TypeError: If the dbt task is not a subclass of ManifestTask.
         """
+        try:
+            from dbt.exceptions import InternalException as DbtException
+        except ImportError:
+            from dbt.exceptions import DbtRuntimeError as DbtException
+
         if isinstance(task, ManifestTask) is False:
             raise TypeError(
                 f"Patching requires an instance of ManifestTask, not {type(task)}"
@@ -220,7 +224,7 @@ class BaseConfig:
                 elif uid in task.manifest.sources:
                     task._flattened_nodes.append(task.manifest.sources[uid])
                 else:
-                    raise InternalException(
+                    raise DbtException(
                         f"Node selection returned {uid}, expected a node or a "
                         f"source"
                     )

--- a/airflow_dbt_python/hooks/dbt.py
+++ b/airflow_dbt_python/hooks/dbt.py
@@ -186,9 +186,9 @@ class BaseConfig:
             TypeError: If the dbt task is not a subclass of ManifestTask.
         """
         try:
-            from dbt.exceptions import InternalException as DbtException
+            from dbt.exceptions import InternalException as DbtException  # type: ignore
         except ImportError:
-            from dbt.exceptions import DbtRuntimeError as DbtException
+            from dbt.exceptions import DbtRuntimeError as DbtException  # type: ignore
 
         if isinstance(task, ManifestTask) is False:
             raise TypeError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "airflow-dbt-python"
-version = "0.15.2"
+version = "0.15.3"
 description = "A dbt operator and hook for Airflow"
 authors = ["Tomás Farías Santana <tomas@tomasfarias.dev>"]
 license = "MIT"


### PR DESCRIPTION
dbt v1.4.1 replaced `InternalException` for `DbtRuntimeError`. `airflow-dbt-python` is currently underworking heavy refactoring in a different branch, but this issue is relatively simple to fix and makes us unusable, so it requires a quick patch. 

Closes #91 