### PR TITLE
feat: Provide env_vars to update environment variables

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,11 +3,15 @@ name: CI
 on:
   push:
     branches: [ master ]
+    paths:
+      - '**.py'
     tags:
       - "v*"
   pull_request:
     branches:
-    - master
+      - master
+    paths:
+      - '**.py'
 
 jobs:
   test:

--- a/airflow_dbt_python/operators/dbt.py
+++ b/airflow_dbt_python/operators/dbt.py
@@ -5,7 +5,7 @@ import datetime as dt
 import os
 from dataclasses import asdict, is_dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from airflow.exceptions import AirflowException
 from airflow.models.baseoperator import BaseOperator
@@ -24,6 +24,7 @@ base_template_fields = [
     "target",
     "state",
     "vars",
+    "env_vars",
 ]
 
 
@@ -95,6 +96,7 @@ class DbtBaseOperator(BaseOperator):
         upload_dbt_project: bool = False,
         delete_before_upload: bool = False,
         replace_on_upload: bool = False,
+        env_vars: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -145,6 +147,7 @@ class DbtBaseOperator(BaseOperator):
         self.upload_dbt_project = upload_dbt_project
         self.delete_before_upload = delete_before_upload
         self.replace_on_upload = replace_on_upload
+        self.env_vars = env_vars
 
         self._dbt_hook: Optional[DbtHook] = None
 

--- a/airflow_dbt_python/utils/env.py
+++ b/airflow_dbt_python/utils/env.py
@@ -1,0 +1,22 @@
+"""Provides utilities to interact with environment variables."""
+import copy
+import os
+from contextlib import contextmanager
+from typing import Any, Dict, Optional
+
+
+@contextmanager
+def update_environment(env_vars: Optional[Dict[str, Any]] = None):
+    """Update current environment with env_vars and restore afterwards."""
+    if not env_vars:
+        # Nothing to update or restore afterwards, so we return early
+        yield os.environ
+        return
+
+    restore_env = copy.deepcopy(os.environ)
+    os.environ.update({k: str(v) for k, v in env_vars.items()})
+
+    try:
+        yield os.environ
+    finally:
+        os.environ = restore_env

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -186,6 +186,21 @@ def profiles_file(tmp_path_factory, database):
 
 
 @pytest.fixture(scope="session")
+def profiles_file_with_env(tmp_path_factory):
+    """Create a profiles.yml file that relies on env variables for db connection."""
+    p = tmp_path_factory.mktemp(".dbt_with_env") / "profiles.yml"
+    profiles_content = PROFILES.format(
+        host="\"{{ env_var('DBT_HOST') }}\"",
+        user="\"{{ env_var('DBT_USER') }}\"",
+        port="\"{{ env_var('DBT_PORT') | int }}\"",
+        password="\"{{ env_var('DBT_ENV_SECRET_PASSWORD') }}\"",
+        dbname="\"{{ env_var('DBT_DBNAME') }}\"",
+    )
+    p.write_text(profiles_content)
+    return p
+
+
+@pytest.fixture(scope="session")
 def airflow_conns(database):
     """Create Airflow connections for testing.
 

--- a/tests/hooks/dbt/test_dbt_seed.py
+++ b/tests/hooks/dbt/test_dbt_seed.py
@@ -26,7 +26,7 @@ def test_dbt_seed_task(profiles_file, dbt_project_file, seed_files):
 
 
 def test_dbt_seed_task_with_env_vars_profile(
-    hook, profiles_file_with_env, dbt_project_file, model_files, database
+    hook, profiles_file_with_env, dbt_project_file, seed_files, database
 ):
     """Test a dbt seed task that can render env variables in profile."""
     env = {
@@ -38,10 +38,10 @@ def test_dbt_seed_task_with_env_vars_profile(
     }
 
     result = hook.run_dbt_task(
-        "run",
+        "seed",
         project_dir=dbt_project_file.parent,
         profiles_dir=profiles_file_with_env.parent,
-        select=[str(m.stem) for m in model_files],
+        select=[str(s.stem) for s in seed_files],
         env_vars=env,
     )
 

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -1,0 +1,35 @@
+"""Unit tests for environment utilities."""
+import os
+
+from airflow_dbt_python.utils.env import update_environment
+
+
+def test_update_environment():
+    """Test the update_environment context manager."""
+    os.environ["KEEP_THIS_ENVAR"] = "123456"
+
+    assert "TEST_ENVAR0" not in os.environ
+    assert "TEST_ENVAR1" not in os.environ
+
+    env_vars = {"TEST_ENVAR0": 1, "TEST_ENVAR1": "abc"}
+
+    with update_environment(env_vars) as env:
+        assert os.environ.get("TEST_ENVAR0") == "1"
+        assert env.get("TEST_ENVAR0") == "1"
+        assert os.environ.get("TEST_ENVAR1") == "abc"
+        assert env.get("TEST_ENVAR1") == "abc"
+        assert os.environ.get("KEEP_THIS_ENVAR") == "123456"
+        assert env.get("KEEP_THIS_ENVAR") == "123456"
+
+    assert "TEST_ENVAR0" not in os.environ
+    assert "TEST_ENVAR1" not in os.environ
+    assert "KEEP_THIS_ENVAR" in os.environ
+    assert os.environ.get("KEEP_THIS_ENVAR") == "123456"
+
+
+def test_update_environment_without_env_vars():
+    """Assert update_environment is a no-op if no updates are required."""
+    with update_environment({}):
+        os.environ["KEEP_THIS_ENVAR"] = "123456"
+
+    assert "KEEP_THIS_ENVAR" in os.environ


### PR DESCRIPTION
Closes #88 

Environment variables are used by dbt to template configuration files. Although users can now modify the environment of Airflow workers, there is no interface for them to do it in airflow-dbt-python.

This commit adds an env_vars argument that can take a dictionary of environment variables to set during dbt execution. This can be useful for folks who wish to keep their profiles.yml templates.