### PR TITLE
chore: Version v1.0.0 bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "airflow-dbt-python"
-version = "1.0.0b2"
+version = "1.0.0"
 description = "A collection of Airflow operators, hooks, and utilities to execute dbt commands"
 authors = ["Tomás Farías Santana <tomas@tomasfarias.dev>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tomasfarias/airflow-dbt-python"
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
 
     "Intended Audience :: Developers",
 
@@ -21,7 +21,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.7.2, <3.12.0"
+python = ">=3.7.2"
 
 apache-airflow = { version = ">=2.0", optional = true }
 apache-airflow-providers-amazon = { version = ">=3.0.0", optional = true }


### PR DESCRIPTION
Pre-release v1.0.0 versions have been available since 2023-02-20, and no breaking bugs have been reported, so this PR finally bumps the version to v1.0.0 for a full-fledged release. I feel confident in the API we have built, and if we waited for the work still to do there would never be a release.

The release notes will comment on breaking changes and recommend users to test out v1 in case they didn't already test the pre-release versions.

Some features didn't make it in and are planned for v1.1, both of them related to supporting different sources for artifacts (and could actually be seen as one two sides of one new feature):
* https://github.com/tomasfarias/airflow-dbt-python/issues/90
* https://github.com/tomasfarias/airflow-dbt-python/issues/67