### PR TITLE
 fix: Typo in template field

### DIFF
--- a/airflow_dbt_python/operators/dbt.py
+++ b/airflow_dbt_python/operators/dbt.py
@@ -519,7 +519,7 @@ class DbtLsOperator(DbtBaseOperator):
     """
 
     template_fields = (
-        base_template_fields + selection_template_fields + ["resource_type"]
+        base_template_fields + selection_template_fields + ["resource_types"]
     )
 
     def __init__(

--- a/airflow_dbt_python/utils/configs.py
+++ b/airflow_dbt_python/utils/configs.py
@@ -686,7 +686,7 @@ class RunTaskConfig(TableMutabilityConfig):
 class RunOperationTaskConfig(BaseConfig):
     """Dbt run-operation task arguments."""
 
-    args: dict[str, Any] | str = dataclasses.field(default_factory=dict)
+    args: dict[str, Any] | str = dataclasses.field(default_factory=dict)  # type: ignore
     cls: Type[BaseTask] = dataclasses.field(default=RunOperationTask, init=False)
     macro: Optional[str] = None
     which: str = dataclasses.field(default="run-operation", init=False)

--- a/tests/operators/test_dbt_list.py
+++ b/tests/operators/test_dbt_list.py
@@ -86,3 +86,41 @@ def test_dbt_ls_all(
     ]
 
     assert all_files == expected
+
+
+def test_dbt_ls_all_with_default(
+    profiles_file,
+    dbt_project_file,
+    seed_files,
+    model_files,
+    singular_tests_files,
+    generic_tests_files,
+    snapshot_files,
+):
+    """Test dbt list operator by listing all resources."""
+    op = DbtLsOperator(
+        task_id="dbt_task",
+        project_dir=dbt_project_file.parent,
+        profiles_dir=profiles_file.parent,
+        do_xcom_push=True,
+    )
+    all_files = op.execute({})
+
+    expected = [
+        "test.model_1",
+        "test.model_2",
+        "test.model_3",
+        "test.model_4",
+        "test.seed_1",
+        "test.seed_2",
+        "test.snapshot_1.test_snapshot",
+        "test.accepted_values_model_2_field1__123__456",
+        "test.not_null_model_2_field1",
+        "test.not_null_model_2_field2",
+        "test.singular_test_1",
+        "test.singular_test_2",
+        "test.unique_model_2_field1",
+        "test.unique_model_2_field2",
+    ]
+
+    assert all_files == expected


### PR DESCRIPTION
Although unable to reproduce #128, this looks like a typo in the template field. Let's see if fixing it causes any issues.

If tests pass, then we'll close #128 until further information.