### PR TITLE
fix(cd): Properly fail deploy if CI fails

### DIFF
--- a/.github/workflows/tagged_release.yml
+++ b/.github/workflows/tagged_release.yml
@@ -9,13 +9,22 @@ jobs:
   gh_tagged_release:
     runs-on: ubuntu-latest
     steps:
-      - name: Wait for Tests to succeed
+      - name: Wait for CI
         uses: fountainhead/action-wait-for-check@v1.0.0
-        id: wait-for-test
+        id: wait-for-ci
         with:
           token: ${{ secrets.GH_DEPLOY_TOKEN }}
           checkName: CI
           ref: ${{ github.sha }}
+          # Wait for one hour
+          timeoutSeconds: 3600
+          intervalSeconds: 60
+
+      - name: Fail if CI failed
+        if: steps.wait-for-ci.outputs.conclusion != 'success'
+        run: |
+          echo "CI failed or didn't complete in time"
+          exit 1
 
       - name: Checkout
         uses: actions/checkout@v2.3.4

--- a/.github/workflows/tagged_release.yml
+++ b/.github/workflows/tagged_release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Wait for CI
-        uses: fountainhead/action-wait-for-check@v1.0.0
+        uses: fountainhead/action-wait-for-check@v1.2.0
         id: wait-for-ci
         with:
           token: ${{ secrets.GH_DEPLOY_TOKEN }}


### PR DESCRIPTION
As part of our continuous deployment workflow, we have a step that
waits for our CI workflow to finish successfully. However, the action
used to wait for the CI workflow doesn't fail on a timeout, it just
sets an output variable.

So, we should have an extra step to check the output and fail
appropriately.

Finally, we shouldn't be timing out at all. CI takes roughly 20
minutes, so I'm bumping the timeout to an hour to make sure we have
plenty of time to wait for that.