### PR TITLE
fix(git-hook): Pass branch as bytes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
         name: Detect secrets
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.257'
+    rev: 'v0.11.7'
     hooks:
       - id: ruff
         name: Linting with ruff

--- a/airflow_dbt_python/hooks/fs/git.py
+++ b/airflow_dbt_python/hooks/fs/git.py
@@ -157,7 +157,11 @@ class DbtGitFSHook(SSHHook, DbtFSHook):
         client, path, branch = self.get_git_client_path(source)
 
         client.clone(
-            path, str(destination), mkdir=not destination.exists(), branch=branch
+            path,
+            str(destination),
+            mkdir=not destination.exists(),
+            # NOTE: Dulwich expects branch to be bytes if defined.
+            branch=branch.encode("utf-8") if isinstance(branch, str) else branch,
         )
 
     def get_git_client_path(self, url: URL) -> Tuple[GitClients, str, Optional[str]]:

--- a/tests/hooks/test_git_hook.py
+++ b/tests/hooks/test_git_hook.py
@@ -4,6 +4,7 @@ import multiprocessing
 import os
 import platform
 import shutil
+import typing
 
 import pytest
 from dulwich.repo import Repo
@@ -295,7 +296,7 @@ def repo_name():
 
 
 @pytest.fixture
-def repo_branch(request) -> bytes | None:
+def repo_branch(request) -> typing.Optional[bytes]:
     """A configurable local git repo branch."""
     try:
         return request.param


### PR DESCRIPTION
Dulwich expects repo branch to be bytes, not str. This seems to be a
gap in the type hinting of dulwich, as other arguments to client.clone
can be passed as str.

Regardless, as a workaround, we can encode branch as bytes.