### PR TITLE
feat: add DbtTrinoHook

### DIFF
--- a/airflow_dbt_python/hooks/target.py
+++ b/airflow_dbt_python/hooks/target.py
@@ -492,3 +492,38 @@ class DbtSparkHook(DbtConnectionHook):
         ),
     ]
     conn_extra_params = []
+
+
+class DbtTrinoHook(DbtConnectionHook):
+    """A hook to interact with dbt using a Trino connection."""
+
+    conn_type = "trino"
+    hook_name = "dbt Trino Hook"
+    airflow_conn_types = (conn_type,)
+
+    conn_params = [
+        "host",
+        DbtConnectionParam("schema", default="public"),
+        DbtConnectionParam("login", "user"),
+        "password",
+        DbtConnectionParam("port", default=443),
+    ]
+
+    conn_extra_params = [
+        DbtConnectionParam("type", default="trino"),
+        DbtConnectionParam("method", default="none"),
+        DbtConnectionParam("http_scheme", default="https"),
+        DbtConnectionParam("verify", default=True),
+        DbtConnectionParam("database", "catalog", "hive"),
+        "catalog",
+        "host",
+        "port",
+        DbtConnectionParam("user", "user"),
+        "password",
+        "schema",
+        "session_properties",
+        "http_headers",
+        "role",
+        "client_tags",
+        "source",
+    ]

--- a/tests/hooks/test_trino.py
+++ b/tests/hooks/test_trino.py
@@ -16,11 +16,11 @@ def test_trino_registration():
           "method": "ldap",
           "user": "user",
           "password": "pass",
-          "host": "trino-etl.example",
+          "host": "trino.example",
           "port": 443,
           "http_scheme": "https",
-          "database": "ads_dwh_hdfs",
-          "schema": "ads_platform_dwh",
+          "database": "example",
+          "schema": "example",
           "verify": false
         }
         """,
@@ -31,12 +31,12 @@ def test_trino_registration():
 
     assert details["type"] == "trino"
     assert details["method"] == "ldap"
-    assert details["host"] == "trino-etl.example"
+    assert details["host"] == "trino.example"
     assert details["port"] == 443
     assert details["user"] == "user"
     assert details["password"] == "pass"
-    assert details["schema"] == "ads_platform_dwh"
-    assert details["catalog"] == "ads_dwh_hdfs"
+    assert details["schema"] == "example"
+    assert details["catalog"] == "example"
     assert details["verify"] is False
 
 

--- a/tests/hooks/test_trino.py
+++ b/tests/hooks/test_trino.py
@@ -1,0 +1,65 @@
+"""Tests for the DbtTrinoHook."""
+
+from airflow.models.connection import Connection
+
+from airflow_dbt_python.hooks.target import DbtConnectionHook, DbtTrinoHook
+
+
+def test_trino_registration():
+    """Ensure that a Trino connection is mapped to a valid dbt profile dict."""
+    conn = Connection(
+        conn_id="my_trino",
+        conn_type="trino",
+        extra="""
+        {
+          "type": "trino",
+          "method": "ldap",
+          "user": "user",
+          "password": "pass",
+          "host": "trino-etl.example",
+          "port": 443,
+          "http_scheme": "https",
+          "database": "ads_dwh_hdfs",
+          "schema": "ads_platform_dwh",
+          "verify": false
+        }
+        """,
+    )
+
+    trino_hook = DbtTrinoHook(conn=conn)
+    details = trino_hook.get_dbt_details_from_connection(conn)
+
+    assert details["type"] == "trino"
+    assert details["method"] == "ldap"
+    assert details["host"] == "trino-etl.example"
+    assert details["port"] == 443
+    assert details["user"] == "user"
+    assert details["password"] == "pass"
+    assert details["schema"] == "ads_platform_dwh"
+    assert details["catalog"] == "ads_dwh_hdfs"
+    assert details["verify"] is False
+
+
+def test_trino_catalog_overrides_database():
+    """Ensure that explicit catalog overrides database → catalog fallback."""
+    conn = Connection(
+        conn_id="my_trino_catalog",
+        conn_type="trino",
+        extra="""
+        {
+          "type": "trino",
+          "user": "u",
+          "password": "p",
+          "host": "h",
+          "port": 8443,
+          "database": "fallback_db",
+          "catalog": "explicit_catalog",
+          "schema": "s"
+        }
+        """,
+    )
+
+    trino_hook = DbtTrinoHook(conn=conn)
+    details = trino_hook.get_dbt_details_from_connection(conn)
+
+    assert details["catalog"] == "explicit_catalog"


### PR DESCRIPTION
### Summary
Add a `DbtTrinoHook` to `airflow_dbt_python/hooks/target.py` for dbt-trino.

- Auto-registered via metaclass with `airflow_conn_types=('trino',)`
- Extras-first behavior: supports legacy 2.2.0 style where everything is in `conn.extra`
- Maps `database` → `catalog` for dbt-trino; explicit `catalog` overrides the fallback
- Accepts host/port/user/password/schema from extras to keep 2.2.0 compatibility
- Optional passthroughs: `session_properties`, `http_headers`, `role`, `client_tags`, `source`

### Example Airflow connection (legacy extras-only)
```json
{
  "type": "trino",
  "method": "ldap",
  "user": "usert",
  "password": "pass",
  "host": "trino.example",
  "port": 443,
  "http_scheme": "https",
  "database": "example",
  "schema": "example",
  "verify": false
}
```

### Tests
- `tests/hooks/test_trino.py` validates:
  - extras-only mapping (host/port/user/password/schema)
  - `database` → `catalog` fallback and explicit `catalog` override

### Notes
- No override of `get_dbt_details_from_connection`.
- No breaking changes to existing hooks.