### PR TITLE
add support for full_refresh in template_fields

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         name: Ensure end of file newline
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.1.1
+    rev: v1.15.0
     hooks:
       - id: mypy
         name: Static type checking

--- a/airflow_dbt_python/operators/dbt.py
+++ b/airflow_dbt_python/operators/dbt.py
@@ -399,7 +399,9 @@ class DbtRunOperator(DbtBaseOperator):
     https://docs.getdbt.com/reference/commands/run.
     """
 
-    template_fields = base_template_fields + selection_template_fields
+    template_fields = (
+        base_template_fields + selection_template_fields + ["full_refresh"]
+    )
 
     def __init__(
         self,
@@ -431,7 +433,9 @@ class DbtSeedOperator(DbtBaseOperator):
     https://docs.getdbt.com/reference/commands/seed.
     """
 
-    template_fields = base_template_fields + selection_template_fields
+    template_fields = (
+        base_template_fields + selection_template_fields + ["full_refresh"]
+    )
 
     def __init__(
         self,
@@ -500,7 +504,9 @@ class DbtCompileOperator(_GraphRunnableOperator):
     https://docs.getdbt.com/reference/commands/compile.
     """
 
-    template_fields = base_template_fields + selection_template_fields
+    template_fields = (
+        base_template_fields + selection_template_fields + ["full_refresh"]
+    )
 
     def __init__(
         self,
@@ -765,7 +771,9 @@ class DbtBuildOperator(DbtBaseOperator):
     https://docs.getdbt.com/reference/commands/build.
     """
 
-    template_fields = base_template_fields + selection_template_fields
+    template_fields = (
+        base_template_fields + selection_template_fields + ["full_refresh"]
+    )
 
     def __init__(
         self,

--- a/airflow_dbt_python/utils/configs.py
+++ b/airflow_dbt_python/utils/configs.py
@@ -619,6 +619,11 @@ class TableMutabilityConfig(SelectionConfig):
         """Call superclass __post_init__."""
         super().__post_init__()
         if isinstance(self.full_refresh, str):
+            if self.full_refresh.lower() not in ("true", "false"):
+                raise ValueError(
+                    f"Invalid value for full_refresh: '{self.full_refresh}'. "
+                    "Expected 'true' or 'false'."
+                )
             self.full_refresh = self.full_refresh.lower() == "true"
 
 

--- a/airflow_dbt_python/utils/configs.py
+++ b/airflow_dbt_python/utils/configs.py
@@ -618,6 +618,8 @@ class TableMutabilityConfig(SelectionConfig):
     def __post_init__(self):
         """Call superclass __post_init__."""
         super().__post_init__()
+        if isinstance(self.full_refresh, str):
+            self.full_refresh = self.full_refresh.lower() == "true"
 
 
 @dataclasses.dataclass

--- a/tests/operators/test_dbt_build.py
+++ b/tests/operators/test_dbt_build.py
@@ -241,22 +241,32 @@ def test_full_refresh_in_template_fields():
     assert "full_refresh" in DbtBuildOperator.template_fields
 
 
-def test_full_refresh_templated():
+@pytest.mark.parametrize(
+    "native,param_value,expected",
+    [
+        (False, "True", "True"),
+        (True, True, True),
+    ],
+)
+def test_full_refresh_templated(native, param_value, expected):
     """Test that full_refresh can be templated with Jinja.
 
-    Airflow renders template fields as strings, so the operator receives a
-    string after rendering. The string-to-bool coercion happens in
-    TableMutabilityConfig and is tested in test_configs.py.
+    With default rendering, Airflow renders to strings. With
+    render_template_as_native_obj=True, native Python types are preserved.
     """
     import pendulum
     from airflow.models.dag import DAG
 
-    dag = DAG(dag_id="test_dag", start_date=pendulum.datetime(2025, 1, 1))
+    dag = DAG(
+        dag_id="test_dag",
+        start_date=pendulum.datetime(2025, 1, 1),
+        render_template_as_native_obj=native,
+    )
     op = DbtBuildOperator(
         task_id="dbt_task",
         full_refresh="{{ params.full_refresh }}",
         dag=dag,
     )
-    context = {"params": {"full_refresh": "True"}}
+    context = {"params": {"full_refresh": param_value}}
     op.render_template_fields(context)
-    assert op.full_refresh == "True"
+    assert op.full_refresh == expected

--- a/tests/operators/test_dbt_build.py
+++ b/tests/operators/test_dbt_build.py
@@ -242,7 +242,12 @@ def test_full_refresh_in_template_fields():
 
 
 def test_full_refresh_templated():
-    """Test that full_refresh can be templated with Jinja."""
+    """Test that full_refresh can be templated with Jinja.
+
+    Airflow renders template fields as strings, so the operator receives a
+    string after rendering. The string-to-bool coercion happens in
+    TableMutabilityConfig and is tested in test_configs.py.
+    """
     import pendulum
     from airflow.models.dag import DAG
 

--- a/tests/operators/test_dbt_build.py
+++ b/tests/operators/test_dbt_build.py
@@ -234,3 +234,24 @@ def test_dbt_build_models_with_project_from_s3(
     build_result = execution_results["results"][0]
 
     assert build_result["status"] == RunStatus.Success
+
+
+def test_full_refresh_in_template_fields():
+    """Test that full_refresh is included in DbtBuildOperator template_fields."""
+    assert "full_refresh" in DbtBuildOperator.template_fields
+
+
+def test_full_refresh_templated():
+    """Test that full_refresh can be templated with Jinja."""
+    import pendulum
+    from airflow.models.dag import DAG
+
+    dag = DAG(dag_id="test_dag", start_date=pendulum.datetime(2025, 1, 1))
+    op = DbtBuildOperator(
+        task_id="dbt_task",
+        full_refresh="{{ params.full_refresh }}",
+        dag=dag,
+    )
+    context = {"params": {"full_refresh": "True"}}
+    op.render_template_fields(context)
+    assert op.full_refresh == "True"

--- a/tests/operators/test_dbt_compile.py
+++ b/tests/operators/test_dbt_compile.py
@@ -214,7 +214,12 @@ def test_full_refresh_in_template_fields():
 
 
 def test_full_refresh_templated():
-    """Test that full_refresh can be templated with Jinja."""
+    """Test that full_refresh can be templated with Jinja.
+
+    Airflow renders template fields as strings, so the operator receives a
+    string after rendering. The string-to-bool coercion happens in
+    TableMutabilityConfig and is tested in test_configs.py.
+    """
     import pendulum
     from airflow.models.dag import DAG
 

--- a/tests/operators/test_dbt_compile.py
+++ b/tests/operators/test_dbt_compile.py
@@ -206,3 +206,24 @@ def test_dbt_compile_uses_correct_argument_according_to_version():
     assert getattr(op, "models", None) is None
     assert op.selector == "a-selector"
     assert getattr(op, "selector_name", None) is None
+
+
+def test_full_refresh_in_template_fields():
+    """Test that full_refresh is included in DbtCompileOperator template_fields."""
+    assert "full_refresh" in DbtCompileOperator.template_fields
+
+
+def test_full_refresh_templated():
+    """Test that full_refresh can be templated with Jinja."""
+    import pendulum
+    from airflow.models.dag import DAG
+
+    dag = DAG(dag_id="test_dag", start_date=pendulum.datetime(2025, 1, 1))
+    op = DbtCompileOperator(
+        task_id="dbt_task",
+        full_refresh="{{ params.full_refresh }}",
+        dag=dag,
+    )
+    context = {"params": {"full_refresh": "True"}}
+    op.render_template_fields(context)
+    assert op.full_refresh == "True"

--- a/tests/operators/test_dbt_compile.py
+++ b/tests/operators/test_dbt_compile.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from textwrap import dedent
 
+import pytest
 from dbt.contracts.results import RunStatus
 
 from airflow_dbt_python.operators.dbt import DbtCompileOperator
@@ -213,22 +214,32 @@ def test_full_refresh_in_template_fields():
     assert "full_refresh" in DbtCompileOperator.template_fields
 
 
-def test_full_refresh_templated():
+@pytest.mark.parametrize(
+    "native,param_value,expected",
+    [
+        (False, "True", "True"),
+        (True, True, True),
+    ],
+)
+def test_full_refresh_templated(native, param_value, expected):
     """Test that full_refresh can be templated with Jinja.
 
-    Airflow renders template fields as strings, so the operator receives a
-    string after rendering. The string-to-bool coercion happens in
-    TableMutabilityConfig and is tested in test_configs.py.
+    With default rendering, Airflow renders to strings. With
+    render_template_as_native_obj=True, native Python types are preserved.
     """
     import pendulum
     from airflow.models.dag import DAG
 
-    dag = DAG(dag_id="test_dag", start_date=pendulum.datetime(2025, 1, 1))
+    dag = DAG(
+        dag_id="test_dag",
+        start_date=pendulum.datetime(2025, 1, 1),
+        render_template_as_native_obj=native,
+    )
     op = DbtCompileOperator(
         task_id="dbt_task",
         full_refresh="{{ params.full_refresh }}",
         dag=dag,
     )
-    context = {"params": {"full_refresh": "True"}}
+    context = {"params": {"full_refresh": param_value}}
     op.render_template_fields(context)
-    assert op.full_refresh == "True"
+    assert op.full_refresh == expected

--- a/tests/operators/test_dbt_run.py
+++ b/tests/operators/test_dbt_run.py
@@ -428,3 +428,23 @@ def test_dbt_run_with_airflow_connection_and_profile(
         assert run_result["status"] == RunStatus.Success
         assert op.profiles_dir == profiles_file.parent
         assert execution_results["args"]["target"] == conn_id or target
+
+
+def test_full_refresh_in_template_fields():
+    """Test that full_refresh is included in DbtRunOperator template_fields."""
+    assert "full_refresh" in DbtRunOperator.template_fields
+
+
+def test_full_refresh_templated():
+    """Test that full_refresh can be templated with Jinja."""
+    from airflow.models.dag import DAG
+
+    dag = DAG(dag_id="test_dag", start_date=pendulum.datetime(2025, 1, 1))
+    op = DbtRunOperator(
+        task_id="dbt_task",
+        full_refresh="{{ params.full_refresh }}",
+        dag=dag,
+    )
+    context = {"params": {"full_refresh": "True"}}
+    op.render_template_fields(context)
+    assert op.full_refresh == "True"

--- a/tests/operators/test_dbt_run.py
+++ b/tests/operators/test_dbt_run.py
@@ -436,7 +436,12 @@ def test_full_refresh_in_template_fields():
 
 
 def test_full_refresh_templated():
-    """Test that full_refresh can be templated with Jinja."""
+    """Test that full_refresh can be templated with Jinja.
+
+    Airflow renders template fields as strings, so the operator receives a
+    string after rendering. The string-to-bool coercion happens in
+    TableMutabilityConfig and is tested in test_configs.py.
+    """
     from airflow.models.dag import DAG
 
     dag = DAG(dag_id="test_dag", start_date=pendulum.datetime(2025, 1, 1))

--- a/tests/operators/test_dbt_run.py
+++ b/tests/operators/test_dbt_run.py
@@ -435,21 +435,31 @@ def test_full_refresh_in_template_fields():
     assert "full_refresh" in DbtRunOperator.template_fields
 
 
-def test_full_refresh_templated():
+@pytest.mark.parametrize(
+    "native,param_value,expected",
+    [
+        (False, "True", "True"),
+        (True, True, True),
+    ],
+)
+def test_full_refresh_templated(native, param_value, expected):
     """Test that full_refresh can be templated with Jinja.
 
-    Airflow renders template fields as strings, so the operator receives a
-    string after rendering. The string-to-bool coercion happens in
-    TableMutabilityConfig and is tested in test_configs.py.
+    With default rendering, Airflow renders to strings. With
+    render_template_as_native_obj=True, native Python types are preserved.
     """
     from airflow.models.dag import DAG
 
-    dag = DAG(dag_id="test_dag", start_date=pendulum.datetime(2025, 1, 1))
+    dag = DAG(
+        dag_id="test_dag",
+        start_date=pendulum.datetime(2025, 1, 1),
+        render_template_as_native_obj=native,
+    )
     op = DbtRunOperator(
         task_id="dbt_task",
         full_refresh="{{ params.full_refresh }}",
         dag=dag,
     )
-    context = {"params": {"full_refresh": "True"}}
+    context = {"params": {"full_refresh": param_value}}
     op.render_template_fields(context)
-    assert op.full_refresh == "True"
+    assert op.full_refresh == expected

--- a/tests/operators/test_dbt_seed.py
+++ b/tests/operators/test_dbt_seed.py
@@ -327,3 +327,24 @@ def test_dbt_seed_with_airflow_connection_and_profile(
         assert run_result["status"] == RunStatus.Success
         assert op.profiles_dir == profiles_file.parent
         assert execution_results["args"]["target"] == conn_id or target
+
+
+def test_full_refresh_in_template_fields():
+    """Test that full_refresh is included in DbtSeedOperator template_fields."""
+    assert "full_refresh" in DbtSeedOperator.template_fields
+
+
+def test_full_refresh_templated():
+    """Test that full_refresh can be templated with Jinja."""
+    import pendulum
+    from airflow.models.dag import DAG
+
+    dag = DAG(dag_id="test_dag", start_date=pendulum.datetime(2025, 1, 1))
+    op = DbtSeedOperator(
+        task_id="dbt_task",
+        full_refresh="{{ params.full_refresh }}",
+        dag=dag,
+    )
+    context = {"params": {"full_refresh": "True"}}
+    op.render_template_fields(context)
+    assert op.full_refresh == "True"

--- a/tests/operators/test_dbt_seed.py
+++ b/tests/operators/test_dbt_seed.py
@@ -335,7 +335,12 @@ def test_full_refresh_in_template_fields():
 
 
 def test_full_refresh_templated():
-    """Test that full_refresh can be templated with Jinja."""
+    """Test that full_refresh can be templated with Jinja.
+
+    Airflow renders template fields as strings, so the operator receives a
+    string after rendering. The string-to-bool coercion happens in
+    TableMutabilityConfig and is tested in test_configs.py.
+    """
     import pendulum
     from airflow.models.dag import DAG
 

--- a/tests/operators/test_dbt_seed.py
+++ b/tests/operators/test_dbt_seed.py
@@ -334,22 +334,32 @@ def test_full_refresh_in_template_fields():
     assert "full_refresh" in DbtSeedOperator.template_fields
 
 
-def test_full_refresh_templated():
+@pytest.mark.parametrize(
+    "native,param_value,expected",
+    [
+        (False, "True", "True"),
+        (True, True, True),
+    ],
+)
+def test_full_refresh_templated(native, param_value, expected):
     """Test that full_refresh can be templated with Jinja.
 
-    Airflow renders template fields as strings, so the operator receives a
-    string after rendering. The string-to-bool coercion happens in
-    TableMutabilityConfig and is tested in test_configs.py.
+    With default rendering, Airflow renders to strings. With
+    render_template_as_native_obj=True, native Python types are preserved.
     """
     import pendulum
     from airflow.models.dag import DAG
 
-    dag = DAG(dag_id="test_dag", start_date=pendulum.datetime(2025, 1, 1))
+    dag = DAG(
+        dag_id="test_dag",
+        start_date=pendulum.datetime(2025, 1, 1),
+        render_template_as_native_obj=native,
+    )
     op = DbtSeedOperator(
         task_id="dbt_task",
         full_refresh="{{ params.full_refresh }}",
         dag=dag,
     )
-    context = {"params": {"full_refresh": "True"}}
+    context = {"params": {"full_refresh": param_value}}
     op.render_template_fields(context)
-    assert op.full_refresh == "True"
+    assert op.full_refresh == expected

--- a/tests/utils/test_configs.py
+++ b/tests/utils/test_configs.py
@@ -508,34 +508,37 @@ def test_base_config_does_not_override_when_value_in_environment(
     assert config.require_generic_test_arguments_property is None
 
 
-def test_table_mutability_config_full_refresh_string_coercion(
+@pytest.mark.parametrize(
+    "input_value,expected",
+    [
+        ("True", True),
+        ("true", True),
+        ("False", False),
+        ("false", False),
+        (True, True),
+        (False, False),
+        (None, None),
+    ],
+)
+def test_table_mutability_config_full_refresh_coercion(
+    profiles_file, dbt_project_file, input_value, expected
+):
+    """Test that full_refresh values are coerced to booleans."""
+    config = RunTaskConfig(
+        profiles_dir=profiles_file.parent,
+        project_dir=dbt_project_file.parent,
+        full_refresh=input_value,
+    )
+    assert config.full_refresh is expected
+
+
+def test_table_mutability_config_full_refresh_invalid_string(
     profiles_file, dbt_project_file
 ):
-    """Test that full_refresh string values are coerced to booleans."""
-    config = RunTaskConfig(
-        profiles_dir=profiles_file.parent,
-        project_dir=dbt_project_file.parent,
-        full_refresh="True",
-    )
-    assert config.full_refresh is True
-
-    config = RunTaskConfig(
-        profiles_dir=profiles_file.parent,
-        project_dir=dbt_project_file.parent,
-        full_refresh="False",
-    )
-    assert config.full_refresh is False
-
-    config = RunTaskConfig(
-        profiles_dir=profiles_file.parent,
-        project_dir=dbt_project_file.parent,
-        full_refresh=None,
-    )
-    assert config.full_refresh is None
-
-    config = RunTaskConfig(
-        profiles_dir=profiles_file.parent,
-        project_dir=dbt_project_file.parent,
-        full_refresh=True,
-    )
-    assert config.full_refresh is True
+    """Test that invalid full_refresh strings raise a ValueError."""
+    with pytest.raises(ValueError, match="Invalid value for full_refresh"):
+        RunTaskConfig(
+            profiles_dir=profiles_file.parent,
+            project_dir=dbt_project_file.parent,
+            full_refresh="treu",
+        )

--- a/tests/utils/test_configs.py
+++ b/tests/utils/test_configs.py
@@ -506,3 +506,36 @@ def test_base_config_does_not_override_when_value_in_environment(
         )
     assert config.fail_fast is None
     assert config.require_generic_test_arguments_property is None
+
+
+def test_table_mutability_config_full_refresh_string_coercion(
+    profiles_file, dbt_project_file
+):
+    """Test that full_refresh string values are coerced to booleans."""
+    config = RunTaskConfig(
+        profiles_dir=profiles_file.parent,
+        project_dir=dbt_project_file.parent,
+        full_refresh="True",
+    )
+    assert config.full_refresh is True
+
+    config = RunTaskConfig(
+        profiles_dir=profiles_file.parent,
+        project_dir=dbt_project_file.parent,
+        full_refresh="False",
+    )
+    assert config.full_refresh is False
+
+    config = RunTaskConfig(
+        profiles_dir=profiles_file.parent,
+        project_dir=dbt_project_file.parent,
+        full_refresh=None,
+    )
+    assert config.full_refresh is None
+
+    config = RunTaskConfig(
+        profiles_dir=profiles_file.parent,
+        project_dir=dbt_project_file.parent,
+        full_refresh=True,
+    )
+    assert config.full_refresh is True


### PR DESCRIPTION
                                                                                                                                                                                                          
  ## Summary                             
  - Adds `full_refresh` to `template_fields` on `DbtRunOperator`, `DbtSeedOperator`, `DbtCompileOperator`, and `DbtBuildOperator`, enabling Jinja templating in DAG definitions.                          
  - Adds string-to-bool coercion in `TableMutabilityConfig.__post_init__` to handle Airflow rendering `full_refresh` as a string after template resolution.                                               
                                                                                                                                                                                                          
  ## Example usage                                                                                                                                                                                        
  ```python                                                                                                                                                                                               
  DbtRunOperator(                        
      task_id="dbt_run",                                                                                                                                                                                  
      full_refresh="{{ params.full_refresh }}",
  )
```                                                                                                                                                                                                  
                                       
 ## Test plan                              

  - Added `test_full_refresh_in_template_fields` for each of the 4 operators                                                                                                                                
  - Added `test_full_refresh_templated` for each of the 4 operators
  - Added `test_table_mutability_config_full_refresh_string_coercion` for string-to-bool coercion                                                                                                           
  - Verified existing tests still pass

## Development Approach

- First added the tests and verified they failed
- Then made the code changes
- Then verified the tests now succeed and any already existing tests still succeed          