### PR TITLE
chore: Bump CI versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,29 +28,31 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
+          # TODO: Requires dbt 1.12 which is in beta at the time of check.
+          # - '3.14'
           - '3.13'
           - '3.12'
           - '3.11'
           - '3.10'
         airflow-version:
-          # Latest release as of 2025-12-27
+          # Latest release as of 2026-05-24
           # See: https://airflow.apache.org/docs/apache-airflow/stable/release_notes.html
-          - '3.1.5'
-          # GCP Cloud Composer latest as of 2025-12-27
+          - '3.2.1'
+          # GCP Cloud Composer latest as of 2026-05-24
           # See: https://docs.cloud.google.com/composer/docs/composer-versions
-          # TODO: Uncomment once 'SUPERVISOR_COMMS' import bug is figured out
-          # This is fixed in later versions of Airflow.
-          # - '3.1.0'
-          # AWS MWAA latest as of 2025-12-27
+          - '3.1.7'
+          # AWS MWAA latest as of 2026-05-24
           # See: https://docs.aws.amazon.com/mwaa/latest/userguide/airflow-versions.html
-          - '3.0.6'
+          # TODO: Uncomment once latest stable no longer matches MWAA latest. At the
+          # time of check, they are the same.
+          # - '3.2.1'
         dbt-version:
           - '1.11.2'
           - '1.10.17'
         exclude:
-          # Airflow added 3.13 support in >=3.1
-          - airflow-version: '3.0.6'
-            python-version: '3.13'
+          # Airflow added 3.14 support in >=3.2
+          - airflow-version: '3.1.7'
+            python-version: '3.14'
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -149,6 +149,7 @@ jobs:
           allowed-endpoints: >
             files.pythonhosted.org:443
             github.com:443
+            raw.githubusercontent.com:443
             release-assets.githubusercontent.com:443
             api.github.com:443
             pypi.org:443

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
           # time of check, they are the same.
           # - '3.2.1'
         dbt-version:
-          - '1.11.2'
+          - '1.11.11'
           - '1.10.17'
         exclude:
           # Airflow added 3.14 support in >=3.2


### PR DESCRIPTION
Regular update of versions used in CI. Python 3.14 support is postponed until dbt 1.12, see #180 

Should help CI run lighter as we no longer test 3.0.6.